### PR TITLE
slf4j to 1.8.0-beta2 (CVE-2018-8088)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,12 +60,12 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<version>1.7.12</version>
+			<version>1.8.0-beta2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-simple</artifactId>
-			<version>1.7.12</version>
+			<version>1.8.0-beta2</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
slf4j to 1.8.0-beta2 (CVE-2018-8088)
- https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-8088