### PR TITLE
slf4j to 1.7.26-stable (CVE-2018-8088)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,12 +56,12 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<version>1.8.0-beta2</version>
+			<version>1.7.26</version>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-simple</artifactId>
-			<version>1.8.0-beta2</version>
+			<version>1.7.26</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
slf4j to 1.7.26-stable (CVE-2018-8088)
Released after 1.8.0-beta2.