### PR TITLE
fix getter name

### DIFF
--- a/src/main/java/org/igniterealtime/restclient/entity/MUCRoomEntity.java
+++ b/src/main/java/org/igniterealtime/restclient/entity/MUCRoomEntity.java
@@ -270,7 +270,7 @@ public class MUCRoomEntity {
 
     @XmlElementWrapper(name = "memberGroups")
     @XmlElement(name = "memberGroup")
-    public List<String> getmemberGroups() {
+    public List<String> getMemberGroups() {
         return memberGroups;
     }
 
@@ -290,7 +290,7 @@ public class MUCRoomEntity {
 
     @XmlElementWrapper(name = "outcastGroups")
     @XmlElement(name = "outcastGroup")
-    public List<String> getoutcastGroups() {
+    public List<String> getOutcastGroups() {
         return outcastGroups;
     }
 
@@ -310,7 +310,7 @@ public class MUCRoomEntity {
 
     @XmlElementWrapper(name = "adminGroups")
     @XmlElement(name = "adminGroup")
-    public List<String> getadminGroups() {
+    public List<String> getAdminGroups() {
         return adminGroups;
     }
 


### PR DESCRIPTION
I thought about leaving the following for backward compatibility, but it didn't improve the error, so I replaced it completely.

- `getmemberGroups`
- `getoutcastGroups`
- `getadminGroups`

```text
Exception [EclipseLink-50009] (Eclipse Persistence Services - 2.6.0.v20150309-bf26070): org.eclipse.persistence.exceptions.JAXBException
Exception Description: The property or field memberGroups is annotated to be transient so it cannot be included in the propOrder annotation.
```

```text
org.glassfish.jersey.message.internal.MessageBodyProviderNotFoundException: MessageBodyWriter not found for media type=application/json, type=class org.igniterealtime.restclient.entity.MUCRoomEntity, genericType=class org.igniterealtime.restclient.entity.MUCRoomEntity.
	at org.glassfish.jersey.message.internal.WriterInterceptorExecutor$TerminalWriterInterceptor.aroundWriteTo(WriterInterceptorExecutor.java:247) ~[jersey-common-2.24.1.jar:?]
	at org.glassfish.jersey.message.internal.WriterInterceptorExecutor.proceed(WriterInterceptorExecutor.java:162) ~[jersey-common-2.24.1.jar:?]
	at org.glassfish.jersey.message.internal.MessageBodyFactory.writeTo(MessageBodyFactory.java:1130) ~[jersey-common-2.24.1.jar:?]
	at org.glassfish.jersey.client.ClientRequest.doWriteEntity(ClientRequest.java:517) ~[jersey-client-2.24.1.jar:?]
	at org.glassfish.jersey.client.ClientRequest.writeEntity(ClientRequest.java:499) ~[jersey-client-2.24.1.jar:?]
	at org.glassfish.jersey.client.internal.HttpUrlConnector._apply(HttpUrlConnector.java:393) ~[jersey-client-2.24.1.jar:?]
	at org.glassfish.jersey.client.internal.HttpUrlConnector.apply(HttpUrlConnector.java:285) ~[jersey-client-2.24.1.jar:?]
	at org.glassfish.jersey.client.ClientRuntime.invoke(ClientRuntime.java:252) ~[jersey-client-2.24.1.jar:?]
	at org.glassfish.jersey.client.JerseyInvocation$2.call(JerseyInvocation.java:701) ~[jersey-client-2.24.1.jar:?]
	at org.glassfish.jersey.internal.Errors.process(Errors.java:315) ~[jersey-common-2.24.1.jar:?]
	at org.glassfish.jersey.internal.Errors.process(Errors.java:297) ~[jersey-common-2.24.1.jar:?]
	at org.glassfish.jersey.internal.Errors.process(Errors.java:228) ~[jersey-common-2.24.1.jar:?]
	at org.glassfish.jersey.process.internal.RequestScope.runInScope(RequestScope.java:444) ~[jersey-common-2.24.1.jar:?]
	at org.glassfish.jersey.client.JerseyInvocation.invoke(JerseyInvocation.java:697) ~[jersey-client-2.24.1.jar:?]
	at org.glassfish.jersey.client.JerseyInvocation$Builder.method(JerseyInvocation.java:448) ~[jersey-client-2.24.1.jar:?]
	at org.igniterealtime.restclient.RestClient.call(RestClient.java:153) ~[rest-api-client-1.1.5.jar:?]
	at org.igniterealtime.restclient.RestClient.post(RestClient.java:99) ~[rest-api-client-1.1.5.jar:?]
	at org.igniterealtime.restclient.RestApiClient.createChatRoom(RestApiClient.java:202) ~[rest-api-client-1.1.5.jar:?]
```